### PR TITLE
fix: github action

### DIFF
--- a/.github/workflows/pre-commit-action.yaml
+++ b/.github/workflows/pre-commit-action.yaml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  SKIP: ${{ github.ref == 'refs/heads/master' && 'no-commit-to-branch' || '' }}
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
do not run no-commit-to-branch hook on master branch